### PR TITLE
Allow typed tokens of the Tavor format to be defined outside from the parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1392,9 +1392,9 @@ Every token type and interface can have its own token attributes. Currently it i
 
 ### <a name="extend-typed-tokens"></a>Typed tokens
 
-Typed tokens provide additional types for formats. Currently it is not possible to define typed tokens and their arguments externally. Instead they must be implemented directly in the format parsers. For example the method `parseTypedTokenDefinition` of the [Tavor format parser](/parser/tavor.go) has to be extended. To add token attributes to typed tokens, please have a look at the  [token attributes section](#extend-token-attributes). It is only necessary to implement the [Token interface](https://godoc.org/github.com/zimmski/tavor/token#Token), since typed tokens behave like regular tokens. Arguments for the typed tokens have to be currently parsed and validated by hand. They are used as initialization values for the instanced token. It is therefore not possible to lookup argument values after the typed token definition is processed.
-
-> **Note:** The mentioned implementation inconveniences will be addressed in future versions of Tavor.
+Typed tokens provide additional types for formats. It is possible to define new typed tokens by calling the  [`token.RegisterTyped`](https://godoc.org/github.com/zimmski/tavor/token#RegisterTyped) function. It is only necessary to implement the [Token interface](https://godoc.org/github.com/zimmski/tavor/token#Token), since typed tokens behave like regular tokens. Arguments for the typed tokens are used as initialization values for the instanced token. It is therefore not possible to lookup argument values after the typed token definition is processed.
+ 		 
+An example of typed token creation function can be found in [the sequence token](/token/sequences/sequence.go#L29). Currently, the arguments of a typed token are limited to integers. To support new argument types, it is necessary to extend the [ArgumentsTypedParser](https://godoc.org/github.com/zimmski/tavor/token#ArgumentsTypedParser) interface and [its implementation](/parser/typed.go). To add token attributes to typed tokens, please have a look at the  [token attributes section](#extend-token-attributes).
 
 ## <a name="stability"></a>How stable is Tavor?
 

--- a/parser/typed.go
+++ b/parser/typed.go
@@ -1,0 +1,57 @@
+package parser
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type argumentsParser struct {
+	arguments     map[string]string
+	usedArguments map[string]struct{}
+	err           error
+}
+
+func newArgumentsParser(arguments map[string]string) *argumentsParser {
+	return &argumentsParser{
+		arguments:     arguments,
+		usedArguments: make(map[string]struct{}),
+		err:           nil,
+	}
+}
+
+// GetInt tries to parse the argument name and returns its integer value or defaultValue if the argument is not found.
+// The return value is valid only if Err returns nil.
+func (ap *argumentsParser) GetInt(name string, defaultValue int) int {
+	if ap.err != nil {
+		return -1
+	}
+
+	raw, found := ap.arguments[name]
+	if !found {
+		return defaultValue
+	}
+
+	val, err := strconv.Atoi(raw)
+	if err != nil {
+		ap.err = fmt.Errorf("%q needs an integer value", name)
+		return -1
+	}
+
+	ap.usedArguments[name] = struct{}{}
+	return val
+}
+
+// Err returns the first error encountered by the ArgumentsParser
+func (ap *argumentsParser) Err() error {
+	return ap.err
+}
+
+func (ap *argumentsParser) firstUnusedArgument() string {
+	for arg := range ap.arguments {
+		if _, ok := ap.usedArguments[arg]; !ok {
+			return arg
+		}
+	}
+
+	return ""
+}

--- a/token/primitives/int.go
+++ b/token/primitives/int.go
@@ -143,6 +143,20 @@ func NewRangeIntWithStep(from, to, step int) *RangeInt {
 	}
 }
 
+func init() {
+	token.RegisterTyped("Int", func(argParser token.ArgumentsTypedParser) (token.Token, error) {
+		from := argParser.GetInt("from", 0)
+		to := argParser.GetInt("to", math.MaxInt32)
+		step := argParser.GetInt("step", 1)
+
+		if err := argParser.Err(); err != nil {
+			return nil, err
+		}
+
+		return NewRangeIntWithStep(from, to, step), nil
+	})
+}
+
 // From returns the from value of the range
 func (p *RangeInt) From() int {
 	return p.from

--- a/token/sequences/sequence.go
+++ b/token/sequences/sequence.go
@@ -26,6 +26,19 @@ func NewSequence(start, step int) *Sequence {
 	}
 }
 
+func init() {
+	token.RegisterTyped("Sequence", func(argParser token.ArgumentsTypedParser) (token.Token, error) {
+		start := argParser.GetInt("start", 1)
+		step := argParser.GetInt("step", 1)
+
+		if err := argParser.Err(); err != nil {
+			return nil, err
+		}
+
+		return NewSequence(start, step), nil
+	})
+}
+
 // TODO this must be handled without panics
 var errNoSequenceValue = fmt.Sprintf("There is no sequence value to choose from")
 

--- a/token/typed.go
+++ b/token/typed.go
@@ -1,0 +1,73 @@
+package token
+
+import (
+	"fmt"
+	"sort"
+	"text/scanner"
+)
+
+// ArgumentsTypedParser defines a parser for the arguments of a typed token.
+// Parsing stops unrecoverably at the first error. The return value of Err must be checked before using the values returned by precedings calls to GetInt.
+type ArgumentsTypedParser interface {
+	// GetInt tries to parse the argument name and returns its integer value or defaultValue if the argument is not found.
+	// The return value is valid only if Err returns nil.
+	GetInt(name string, defaultValue int) int
+	// Err returns the first error encountered by the ArgumentsTypedParser.
+	Err() error
+}
+
+// CreateTypedFunc defines a function to create a typed token
+type CreateTypedFunc func(argParser ArgumentsTypedParser) (Token, error)
+
+// typedLookup is a mapping from typed token names to their creation functions
+var typedLookup = make(map[string]CreateTypedFunc)
+
+// NewTyped creates a typed token by calling the function registered with the given name.
+// The error return argument is not nil if the name does not exist in the registered typed token list or if the token creation failed.
+func NewTyped(name string, argParser ArgumentsTypedParser, pos scanner.Position) (Token, error) {
+	createTok, ok := typedLookup[name]
+	if !ok {
+		return nil, &ParserError{
+			Message:  fmt.Sprintf("unknown typed token %q", name),
+			Type:     ParseErrorUnknownTypedTokenType,
+			Position: pos,
+		}
+	}
+
+	tok, err := createTok(argParser)
+	if err != nil {
+		return nil, &ParserError{
+			Message:  err.Error(),
+			Type:     ParseErrorInvalidArgumentValue,
+			Position: pos,
+		}
+	}
+
+	return tok, nil
+}
+
+// ListTyped returns a list of all registered typed token names.
+func ListTyped() []string {
+	typedNames := make([]string, 0, len(typedLookup))
+
+	for key := range typedLookup {
+		typedNames = append(typedNames, key)
+	}
+
+	sort.Strings(typedNames)
+
+	return typedNames
+}
+
+// RegisterTyped registers a typed token creation function with the given name.
+func RegisterTyped(name string, ct CreateTypedFunc) {
+	if ct == nil {
+		panic("register typed token is nil")
+	}
+
+	if _, ok := typedLookup[name]; ok {
+		panic("typed token " + name + " already registered")
+	}
+
+	typedLookup[name] = ct
+}


### PR DESCRIPTION
Types tokens are now in charge of parsing their arguments and registering themselves.
I'm wondering if token/types.go should be moved to a separate package `token/typed`so that `token.RegisterTyped` becomes `typed.Register`.